### PR TITLE
Fixing to support long surnames

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -317,7 +317,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         },
     )
     first_name = models.CharField(_('first name'), max_length=30, blank=True)
-    last_name = models.CharField(_('last name'), max_length=30, blank=True)
+    last_name = models.CharField(_('last name'), max_length=60, blank=True)
     email = models.EmailField(_('email address'), blank=True)
     is_staff = models.BooleanField(
         _('staff status'),


### PR DESCRIPTION
Hi, my name is Raony Guimarães Corrêa Do Carmo Lisboa Cardenas. 

For a long time i was having problems to login in djangopackages.com using my github account (https://github.com/pydanny/djangopackages/issues/338). Today I tracked down the problem and it was because my surname is bigger than 30 characters. I'm sure there are other people on the same situation and this already happened with me in other django websites. 

http://pix.toile-libre.org/upload/original/1469699303.png

I'm requesting an increase from 30 to 60 characters on last_name field so my login and others won't break again in the future.
